### PR TITLE
DRAFT TS 107/game state

### DIFF
--- a/packages/client/jest.config.js
+++ b/packages/client/jest.config.js
@@ -8,5 +8,18 @@ export default {
   globals: {
     __SERVER_PORT__: process.env.SERVER_PORT,
   },
+  moduleNameMapper: {
+    '@components/(.*)': '<rootDir>/src/components/$1',
+    '@utils-kit/(.*)': '<rootDir>/src/utils/$1',
+    '@utils/(.*)': '<rootDir>/src/utils/$1',
+    '@api/(.*)': '<rootDir>/src/api/$1',
+    '@pages/(.*)': '<rootDir>/src/pages/$1',
+    '@services/(.*)': '<rootDir>/src/services/$1',
+    '@game/(.*)': '<rootDir>/src/game/$1',
+    '@scenes/(.*)': '<rootDir>/src/game/scenes/$1',
+    '@hooks/(.*)': '<rootDir>/src/hooks/$1',
+    '@store/(.*)': '<rootDir>/src/store/$1',
+    '@constants/(.*)': '<rootDir>/src/constants/$1',
+  },
   setupFilesAfterEnv: ['<rootDir>/jest-setup.ts']
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -48,7 +48,6 @@
     "jest-environment-jsdom": "^29.0.1",
     "lefthook": "^1.1.1",
     "prettier": "^2.7.1",
-    "react-test-renderer": "^18.2.0",
     "sass": "^1.57.1",
     "ts-jest": "^28.0.8",
     "tsconfig-paths": "^4.1.2",

--- a/packages/client/src/game/scenes/MapScene/index.tsx
+++ b/packages/client/src/game/scenes/MapScene/index.tsx
@@ -11,7 +11,7 @@ function LoadScene({ onExit }: SceneProps) {
 
   const dispatch = useAppDispatch()
   const onGameFinish = () => {
-    dispatch(finishLevel({ time: 0 }))
+    dispatch(finishLevel())
   }
 
   useEffect(() => {

--- a/packages/client/src/game/scenes/ResultsScreen/Scene/index.tsx
+++ b/packages/client/src/game/scenes/ResultsScreen/Scene/index.tsx
@@ -3,7 +3,7 @@ import SecondsToHMS from '@utils/secondsFormat'
 import { useFonts } from '@hooks/useFonts'
 import './ResScene.scss'
 import { useAppSelector, useAppDispatch } from 'hooks/redux_typed_hooks'
-import { restartGame } from '@store/slices/game'
+import { resumeGame } from '@store/slices/game'
 import { levelStats } from '@store/selectors'
 import { width, height, center } from '@utils/winsize'
 
@@ -22,13 +22,7 @@ function _RenderStroke(
 }
 
 function ResScene({ onExit }: SceneProps) {
-  const lvlStats = useAppSelector(levelStats) || {
-    levelNum: 1,
-    killCount: 0,
-    coins: 0,
-    time: 0,
-    steps: 0,
-  }
+  const lvlStats = useAppSelector(levelStats)
   const { levelNum, killCount, coins, time, steps } = lvlStats
   const dispatch = useAppDispatch()
   const canvasRef = useRef<HTMLCanvasElement>(null)
@@ -39,7 +33,7 @@ function ResScene({ onExit }: SceneProps) {
   const formatTime = SecondsToHMS(time)
 
   const onRestart = () => {
-    dispatch(restartGame())
+    dispatch(resumeGame())
   }
 
   useEffect(() => {

--- a/packages/client/src/store/index.ts
+++ b/packages/client/src/store/index.ts
@@ -1,11 +1,13 @@
 import { configureStore } from '@reduxjs/toolkit'
 import gameSlice from '@store/slices/game'
 import userSlice from '@store/slices/user'
+import playerSlice from '@store/slices/player'
 
 export const store = configureStore({
   reducer: {
     game: gameSlice,
     user: userSlice,
+    player: playerSlice,
   },
 })
 

--- a/packages/client/src/store/selectors/index.ts
+++ b/packages/client/src/store/selectors/index.ts
@@ -1,10 +1,29 @@
 import type { RootState } from '../index'
 
+// game slice selectors
 export const game = (state: RootState) => state.game
-export const levelStats = (state: RootState) => game(state).levelStats
+export const levelStats = (state: RootState) => ({
+  ...game(state).levelStats,
+  levelNum: game(state).currentLevel,
+})
 export const currentScene = (state: RootState) => game(state).currentScene
+export const selectMove = (state: RootState) => game(state).nextMove
+export const selectPaused = (state: RootState) => game(state).gameState
+// add currentLevel stats to gameTotals
+export const selectGameTotals = (state: RootState) => {
+  const { gameTotals, levelStats } = game(state)
+  Object.keys(gameTotals).forEach(key => {
+    const kkey = key as keyof typeof gameTotals
+    gameTotals[kkey] += levelStats[kkey]
+  })
+  return { gameTotals, levelNum: game(state).currentLevel }
+}
 
+// user slice selectors
 export const selectUserData = (state: RootState) => state.user.data
 export const selectLoadingStatus = (state: RootState) =>
   state.user.loadingStatus
 export const selectLoginStatus = (state: RootState) => state.user.loginStatus
+
+// player slice selectors
+export const selectPlayer = (state: RootState) => state.player

--- a/packages/client/src/store/slices/game.test.ts
+++ b/packages/client/src/store/slices/game.test.ts
@@ -1,0 +1,71 @@
+import reducer, {
+  collectCoins,
+  finishLevel,
+  GameState,
+  kill,
+  NextMove,
+  startGame,
+  step,
+} from '@store/slices/game'
+import SCENES from '@constants/scenes'
+
+const initialState = {
+  gameState: GameState.PAUSED,
+  currentScene: SCENES.LOAD_SCENE,
+  currentLevel: 1,
+  totalLevels: 1,
+  nextMove: NextMove.PLAYER,
+  levelStats: {
+    killCount: 0,
+    coins: 0,
+    time: 0,
+    steps: 0,
+  },
+  gameTotals: {
+    killCount: 0,
+    coins: 0,
+    time: 0,
+    steps: 0,
+  },
+}
+
+describe('Testing game slice', () => {
+  it('should return initial state', () => {
+    expect(reducer(undefined, { type: undefined })).toEqual(initialState)
+  })
+  it('should set map scene and set running state', () => {
+    expect(reducer(initialState, startGame())).toEqual({
+      ...initialState,
+      currentScene: SCENES.MAP_SCENE,
+      gameState: GameState.RUNNING,
+    })
+  })
+  it('should update game totals upon level finish', () => {
+    const levelStats = {
+      killCount: 32,
+      coins: 50,
+      time: 500,
+      steps: 200,
+    }
+    const prevState = { ...initialState, levelStats }
+    expect(reducer(prevState, finishLevel())).toEqual({
+      ...initialState,
+      gameTotals: {
+        killCount: 32,
+        coins: 50,
+        time: 500,
+        steps: 200,
+      },
+      currentScene: SCENES.RESULT_SCENE,
+    })
+  })
+  it('should update steps count in levelStats', () => {
+    expect(reducer(initialState, step()).levelStats.steps).toBe(1)
+  })
+  it('should update kill count in levelStats', () => {
+    expect(reducer(initialState, kill()).levelStats.killCount).toBe(1)
+  })
+  it('should update coins count in levelStats', () => {
+    expect(reducer(initialState, collectCoins(42)).levelStats.coins).toBe(42)
+  })
+})

--- a/packages/client/src/store/slices/game.ts
+++ b/packages/client/src/store/slices/game.ts
@@ -1,74 +1,150 @@
-import { createSlice } from '@reduxjs/toolkit'
+import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import SCENES from '@constants/scenes'
 
-export interface InitialState {
-  currentScene: SCENES
-  level: number
-  levelStats: ResultsProps
+export enum NextMove {
+  PLAYER,
+  WORLD,
 }
 
-export const initialState: InitialState = {
+export enum GameState {
+  RUNNING,
+  PAUSED,
+}
+
+export const initialState = {
+  gameState: GameState.PAUSED,
   currentScene: SCENES.LOAD_SCENE,
-  level: 1,
+  currentLevel: 1,
+  totalLevels: 1,
+  nextMove: NextMove.PLAYER,
   levelStats: {
-    levelNum: 1,
-    killCount: 100,
-    coins: 50,
-    time: 60,
-    steps: 1114,
+    killCount: 0,
+    coins: 0,
+    time: 0,
+    steps: 0,
+  },
+  gameTotals: {
+    killCount: 0,
+    coins: 0,
+    time: 0,
+    steps: 0,
   },
 }
 
-interface ResultsProps {
-  levelNum: number
-  killCount: number
-  coins: number
-  time: number
-  steps: number
+const resetLevelStats = (state: typeof initialState) => {
+  state.levelStats = initialState.levelStats
 }
 
-export enum ActionType {
-  restartGame,
-  startGame,
-  nextLevel,
-  showLoader,
-  finishLevel,
+const updateTotals = (state: typeof initialState) => {
+  state.gameTotals.coins += state.levelStats.coins
+  state.gameTotals.killCount += state.levelStats.killCount
+  state.gameTotals.steps += state.levelStats.steps
+  state.gameTotals.time += state.levelStats.time
+  resetLevelStats(state)
+}
+
+const endGame = (state: typeof initialState) => {
+  state.gameState = GameState.PAUSED
+  updateTotals(state)
+  state.currentScene = SCENES.RESULT_SCENE
 }
 
 const gameSlice = createSlice({
   name: 'game',
   initialState: initialState,
   reducers: {
-    restartGame(state) {
-      state.currentScene = SCENES.MAP_SCENE
-    },
+    // start/stop/pause/resume
     startGame(state) {
+      return {
+        ...state,
+        gameState: GameState.RUNNING,
+        currentScene: SCENES.MAP_SCENE,
+      }
+    },
+    finishGame(state) {
+      endGame(state)
+    },
+    pauseGame(state) {
+      state.gameState = GameState.PAUSED
+      // TODO какую сцену показывать в паузе? Пока ставим RESULT_SCENE
+      state.currentScene = SCENES.RESULT_SCENE
+    },
+    resumeGame(state) {
       state.currentScene = SCENES.MAP_SCENE
+      state.gameState = GameState.RUNNING
+    },
+    // levels
+    finishLevel(state) {
+      const nextLevelNumber = state.currentLevel + 1
+      if (nextLevelNumber > state.totalLevels) {
+        endGame(state)
+        return
+      }
+      updateTotals(state)
+      state.gameState = GameState.PAUSED
+      // TODO какую сцену показывать в паузе? Пока ставим RESULT_SCENE
+      state.currentScene = SCENES.RESULT_SCENE
+    },
+    resetLevel(state) {
+      resetLevelStats(state)
+      state.gameState = GameState.RUNNING
     },
     nextLevel(state) {
-      state.level += 1
+      state.currentLevel += 1
+      resetLevelStats(state)
       state.currentScene = SCENES.MAP_SCENE
     },
+    // scene selectors
     showLoader(state) {
+      // TODO скорее всего, не нужно здесь
       state.currentScene = SCENES.LOAD_SCENE
     },
     showStartScene(state) {
+      // TODO скорее всего, не нужно, как отдельый редюсер
       state.currentScene = SCENES.START_SCENE
     },
-    finishLevel(state, action) {
-      state.currentScene = SCENES.RESULT_SCENE
-      state.levelStats = action.payload.stats
+    // layer stats
+    kill(state) {
+      state.levelStats.killCount += 1
+    },
+    collectCoin(state) {
+      state.levelStats.coins += 1
+    },
+    collectCoins(state, action: PayloadAction<number>) {
+      state.levelStats.coins += action.payload
+    },
+    step(state) {
+      state.levelStats.steps += 1
+    },
+    addTime(state, action: PayloadAction<number>) {
+      state.levelStats.time += action.payload
+    },
+    // turns
+    giveMoveToPlayer(state) {
+      state.nextMove = NextMove.PLAYER
+    },
+    giveMoveToWorld(state) {
+      state.nextMove = NextMove.WORLD
     },
   },
 })
 
 export const {
-  restartGame,
   startGame,
-  nextLevel,
-  showLoader,
-  showStartScene,
+  finishGame,
+  pauseGame,
+  resumeGame,
   finishLevel,
+  resetLevel,
+  nextLevel,
 } = gameSlice.actions
+
+export const { giveMoveToPlayer, giveMoveToWorld } = gameSlice.actions
+
+// TODO скорее всего, не нужно
+export const { showLoader, showStartScene } = gameSlice.actions
+
+export const { kill, collectCoin, collectCoins, step, addTime } =
+  gameSlice.actions
 
 export default gameSlice.reducer

--- a/packages/client/src/store/slices/player.test.ts
+++ b/packages/client/src/store/slices/player.test.ts
@@ -1,0 +1,41 @@
+// import {store} from '@store/index'
+import reducer, { setClass, PlayerClass, injure, heal } from './player'
+
+const defaultPlayer = {
+  playerClass: PlayerClass.L3X3III,
+  props: {
+    skill: 32,
+    hits: 32,
+    strength: 128,
+    armor: 64,
+  },
+  health: 100,
+}
+const gineffClassProps = {
+  skill: 32,
+  hits: 64,
+  strength: 128,
+  armor: 32,
+}
+
+describe('Testing player slice', () => {
+  it('should return the initial state', () => {
+    expect(reducer(undefined, { type: undefined })).toEqual(defaultPlayer)
+  })
+  it('should change player class', () => {
+    expect(reducer(defaultPlayer, setClass(PlayerClass.GINEFF))).toEqual({
+      playerClass: PlayerClass.GINEFF,
+      props: gineffClassProps,
+      health: 100,
+    })
+  })
+  it('should reduce health by amount', () => {
+    expect(reducer(defaultPlayer, injure(25)).health).toBe(75)
+  })
+  it('should reduce health but not below zero', () => {
+    expect(reducer(defaultPlayer, injure(125)).health).toBe(0)
+  })
+  it('should not set health above 100', () => {
+    expect(reducer(defaultPlayer, heal(125)).health).toBe(100)
+  })
+})

--- a/packages/client/src/store/slices/player.ts
+++ b/packages/client/src/store/slices/player.ts
@@ -1,0 +1,156 @@
+import {
+  createSlice,
+  PayloadAction,
+  ThunkAction,
+  AnyAction,
+} from '@reduxjs/toolkit'
+import type { RootState } from '@store/index'
+import { pauseGame } from '@store/slices/game'
+
+export enum PlayerClass {
+  L3X3III = 'L3X3III',
+  GINEFF = 'GINEFF',
+  TAURENGOLD = 'TAURENGOLD',
+  NEON_KONCH = 'NEON_KONCH',
+  MITSON = 'MITSON',
+}
+
+const propMaxValues = {
+  skill: 256,
+  hits: 256,
+  strength: 256,
+  armor: 256,
+}
+
+type PlayerProps = typeof propMaxValues
+type PlayerPropName = keyof PlayerProps
+
+const keepInRange = (prop: PlayerPropName, value: number): number => {
+  return Math.max(0, Math.min(propMaxValues[prop], value))
+}
+
+const playerPresets = {
+  [PlayerClass.L3X3III]: {
+    skill: 32,
+    hits: 32,
+    strength: 128,
+    armor: 64,
+  },
+  [PlayerClass.GINEFF]: {
+    skill: 32,
+    hits: 64,
+    strength: 128,
+    armor: 32,
+  },
+  [PlayerClass.TAURENGOLD]: {
+    skill: 64,
+    hits: 64,
+    strength: 64,
+    armor: 64,
+  },
+  [PlayerClass.NEON_KONCH]: {
+    skill: 32,
+    hits: 128,
+    strength: 64,
+    armor: 32,
+  },
+  [PlayerClass.MITSON]: {
+    skill: 32,
+    hits: 32,
+    strength: 64,
+    armor: 128,
+  },
+}
+
+const initialState = {
+  playerClass: PlayerClass.L3X3III,
+  props: playerPresets[PlayerClass.L3X3III],
+  health: 100,
+}
+
+const playerSlice = createSlice({
+  name: 'player',
+  initialState,
+  reducers: {
+    init() {
+      return initialState
+    },
+    setClass(state, action: PayloadAction<typeof initialState.playerClass>) {
+      const playerClass = action.payload
+      state.playerClass = playerClass
+      state.props = playerPresets[playerClass]
+      state.health = 100
+    },
+    reset(state) {
+      state.props = playerPresets[state.playerClass]
+      state.health = 100
+    },
+    upSkill(state, action: PayloadAction<number>) {
+      const newValue = state.props.skill + action.payload
+      state.props.skill = keepInRange('skill', newValue)
+    },
+    downSkill(state, action: PayloadAction<number>) {
+      const newValue = state.props.skill - action.payload
+      state.props.skill = keepInRange('skill', newValue)
+    },
+    upHits(state, action: PayloadAction<number>) {
+      const newValue = state.props.hits + action.payload
+      state.props.hits = keepInRange('hits', newValue)
+    },
+    downHits(state, action: PayloadAction<number>) {
+      const newValue = state.props.hits - action.payload
+      state.props.hits = keepInRange('hits', newValue)
+    },
+    upStrength(state, action: PayloadAction<number>) {
+      const newValue = state.props.strength + action.payload
+      state.props.strength = keepInRange('strength', newValue)
+    },
+    downStrength(state, action: PayloadAction<number>) {
+      const newValue = state.props.strength - action.payload
+      state.props.strength = keepInRange('strength', newValue)
+    },
+    upArmor(state, action: PayloadAction<number>) {
+      const newValue = state.props.armor + action.payload
+      state.props.armor = keepInRange('armor', newValue)
+    },
+    downArmor(state, action: PayloadAction<number>) {
+      const newValue = state.props.armor - action.payload
+      state.props.armor = keepInRange('armor', newValue)
+    },
+    heal(state, action: PayloadAction<number>) {
+      const newValue = state.health + action.payload
+      state.health = Math.min(100, newValue)
+    },
+    injure(state, action: PayloadAction<number>) {
+      const newValue = state.health - action.payload
+      state.health = Math.max(0, newValue)
+    },
+  },
+})
+
+export const { init, reset, setClass } = playerSlice.actions
+
+export const {
+  upArmor,
+  upHits,
+  upSkill,
+  upStrength,
+  downArmor,
+  downHits,
+  downSkill,
+  downStrength,
+} = playerSlice.actions
+
+export const { heal, injure } = playerSlice.actions
+
+export const bite =
+  (amount: number): ThunkAction<void, RootState, unknown, AnyAction> =>
+  (dispatch, getState) => {
+    dispatch(injure(amount))
+    const { player } = getState()
+    if (player.health <= 0) {
+      dispatch(pauseGame())
+    }
+  }
+
+export default playerSlice.reducer

--- a/packages/client/src/store/slices/type.ts
+++ b/packages/client/src/store/slices/type.ts
@@ -1,5 +1,0 @@
-import {InitialState as GameInitialState} from "./game"
-
-export interface RootState {
-  game: GameInitialState
-}

--- a/packages/client/src/store/slices/user.ts
+++ b/packages/client/src/store/slices/user.ts
@@ -14,12 +14,6 @@ export enum Logged {
   Out = 'Out',
 }
 
-export type UserAuth = {
-  id: number
-  login: string
-}
-export const DEFAULT_USER_AUTH = { id: 0, login: '' }
-
 const initialState = {
   loadingStatus: LoadingStatus.Idle,
   loginStatus: Logged.Out,


### PR DESCRIPTION
### Какую задачу решаем

TS-107 Стейт-менеджмент для движка игры

### Скриншоты/видяшка (если есть)

Для тестирования стора вешал действия на кнопку "Создать тему" на странице форума. 
https://yadi.sk/i/zg_-Z3CKP-Rt6A

### TBD (если есть)

Определитсья с экраном паузы

## Store

### The `player` slice

У игрока есть класс, пропсы (характеристики) и здоровье. Здоровье вынесено из объекта пропсов, т. к. пропсами можно управлять с прмощью пресетов класса игрока. Характеристики могут меняться по ходу игры. Сейчас сделано четыре условные характеристики и четыре пресета, каждый со своим набором свойств. Сумма праметоров у всех одинаковая — 256. Не обязательно все использовать. Названия можно поменять, если надо. Пример использования: есть параметр `hits`. С каждым ударом он уменьшается на 1. Если 'хитов' не осталось, то мы не можем никого ударить. Параметр `skill` условный. Можно поменять, например, на `arrows` — запас стрел. И т.д. Для каждой характеристики сделаны отдельные действия добавления/уменьшения с числовым параметром. Пределы — `0 < X < MaxValue`. Много повторяющегося кода; пробовал сделать фабрику, но тогда нет автоматического тайпчекинга. Сейчас же каждый action creator удобно импортировать и использовать.

- `init()` — и так понятно
- `setClass(<PlayerClass>)` — выбор класса
- `reset()` — сброс к дефолту класса
- `upHits(<number>), downHits(<number>)` и т.д. — изменение параметров

  Для управления здоровьем:

- `heal(<number>)` — полечить, добавить _number_ здоровья
- `bite(<number>)` — "откусить" _number_ от здоровья. Если здоровье кончилось, вызывается останов игры. Сделано через thunk, поскольку в этом процессе требуется доступ к `game`-слайсу. С точки зрения использования от этого ничего не меняется.

### The `game` slice

В принципе, все понятно из кода. Разделены `levelStats` и `gameTotals`. При завершении уровня или окончании игры `levelStats` прибавляется к `gameTotals`, после чего `levelStats` обнуляются.
Действие `restartGame` переименовал в `resumeGame`; для запуска игры с начала теперь есть `startGame`, или `resetLevel` для перехода в начало уровня.

### Селекторы

Для игрока пока общий `selectPlayer`, без конкретики.
Для геймплея добавлены:

- `selectMove` — чей следующий ход
- `selectPaused` — состояние `GameState.RUNNING`/`GameState.PAUSED`
- `selectGameTotals` — суммарная статистика level+totals.

### Демо

Для тестирования вешал действия на кнопку "Создать тему" на странице форума. См. видео. Для разработки отключал SW.

## Тесты

Добавил юнит-тесты на редюсеры слайсов `game` и `player`.
Добавил поле `moduleNameMapper ` с алиасами в `jest.config.js`.

## Dependencies

Убрал `react-test-renderer` из зависимостей. Достаточно `@testing-library/jest-dom`.
